### PR TITLE
Crear distribucion-roles.Rmd

### DIFF
--- a/distribucion-roles.Rmd
+++ b/distribucion-roles.Rmd
@@ -1,0 +1,34 @@
+---
+title: "Distribucion de Roles"
+author: "Riva Quiroga"
+date: '`r format(Sys.Date(), "%B %d, %Y")`'
+output:
+  github_document:
+    df_print: kable
+editor_options: 
+  chunk_output_type: console
+---
+
+<!-- archivo generado por distribucion-roles.Rmd -->
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+library(tidyverse)
+library(gsheet)
+distribucion <- gsheet::gsheet2tbl("https://docs.google.com/spreadsheets/d/1BmLq5rrvQBmmyfE4KsurqA3q4iJM8i2HtVOuUFeE5KI/edit#gid=0")
+distribucion <- mutate_all(distribucion, replace_na, "")
+```
+
+### Traducción y revisión de capítulos
+
+```{r}
+distribucion
+```
+
+### Otros roles
+
+* __Administración general__: Riva Quiroga (@rivaquiroga)
+* __Editora de la traducción__: Riva Quiroga (@rivaquiroga)
+* __Administración repositorio R4DS__: Pacha (@pachamaltese)
+* __Responsable paquete traducción de datos__: Edgar Ruiz (@edgararuiz)
+* __Traducción imágenes__: Edgar Ruiz (@edgararuiz)


### PR DESCRIPTION
Automatiza la generación de `distribucion-roles.md`, sin tener que copiar y pegar cambios desde el _sheet_. También consideraría otros campos que en el futuro se agreguen, como por ejemplo _estado de la traducción_ etc.